### PR TITLE
CI: update deprecated set-output

### DIFF
--- a/.github/workflows/release_publish_docker-image.yml
+++ b/.github/workflows/release_publish_docker-image.yml
@@ -29,9 +29,9 @@ jobs:
           if [[ ${{ github.event.action }} == released ]]; then
             TAGS=$TAGS,${DOCKER_IMAGE}:latest
           fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
       - 
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/src/fastly_bouncer/main.py
+++ b/src/fastly_bouncer/main.py
@@ -51,7 +51,6 @@ async def setup_action_for_service(
     service_version,
     sender_chan,
 ) -> ACLCollection:
-
     acl_count = ceil(service_cfg.max_items / ACL_CAPACITY)
     acl_collection = ACLCollection(
         api=fastly_api,


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/