### PR TITLE
Fixes bouncer state drift problem

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ httpx
 trio
 python-dateutil
 pycrowdsec
+tenacity

--- a/src/fastly_bouncer/fastly_api.py
+++ b/src/fastly_bouncer/fastly_api.py
@@ -80,7 +80,9 @@ class VCL:
 
 
 async def raise_on_4xx_5xx(response):
-    response.raise_for_status()
+    if response.is_error:
+        await response.aread()
+        response.raise_for_status()
 
 
 class FastlyAPI:
@@ -99,7 +101,7 @@ class FastlyAPI:
     async def get_version_to_clone(self, service_id: str) -> str:
         """
         Gets the version to clone from. If service has active version, then the active version will be cloned.
-        Else the the version which was last updated would be cloned
+        Else the version which was last updated would be cloned
         """
 
         service_versions_resp = await self.session.get(
@@ -315,9 +317,6 @@ class FastlyAPI:
                     f,
                     self.api_url(f"/service/{acl.service_id}/acl/{acl.id}/entries"),
                 )
-
-        await self.refresh_acl_entries(acl)
-        # TODO BUG: the acls are updated but the service state is not
 
     @staticmethod
     def api_url(endpoint: str) -> str:

--- a/src/fastly_bouncer/fastly_api.py
+++ b/src/fastly_bouncer/fastly_api.py
@@ -284,8 +284,8 @@ class FastlyAPI:
             acl.entries[f"{entry['ip']}/{entry['subnet']}"] = entry["id"]
 
     async def process_acl(self, acl: ACL):
-        logger.debug(with_suffix(f"entries to delete {acl.entries_to_delete}", acl_id=acl.id))
-        logger.debug(with_suffix(f"entries to add {acl.entries_to_add}", acl_id=acl.id))
+        logger.debug(with_suffix(f"entries to delete %s", acl_id=acl.id), acl.entries_to_delete)
+        logger.debug(with_suffix(f"entries to add %s", acl_id=acl.id), acl.entries_to_add)
         update_entries = []
         for entry_to_add in acl.entries_to_add:
             if entry_to_add in acl.entries:

--- a/src/fastly_bouncer/fastly_api.py
+++ b/src/fastly_bouncer/fastly_api.py
@@ -274,7 +274,7 @@ class FastlyAPI:
         resp.json()
         return vcl
 
-    async def refresh_acl_entries(self, acl: ACL) -> Dict[str, str]:
+    async def refresh_acl_entries(self, acl: ACL) -> None:
         resp = await self.session.get(
             self.api_url(f"/service/{acl.service_id}/acl/{acl.id}/entries?per_page={ACL_BATCH_SIZE}")
         )
@@ -282,7 +282,6 @@ class FastlyAPI:
         acl.entries = {}
         for entry in resp:
             acl.entries[f"{entry['ip']}/{entry['subnet']}"] = entry["id"]
-        return acl
 
     async def process_acl(self, acl: ACL):
         logger.debug(with_suffix(f"entries to delete {acl.entries_to_delete}", acl_id=acl.id))
@@ -317,7 +316,7 @@ class FastlyAPI:
                     self.api_url(f"/service/{acl.service_id}/acl/{acl.id}/entries"),
                 )
 
-        acl = await self.refresh_acl_entries(acl)
+        await self.refresh_acl_entries(acl)
         # TODO BUG: the acls are updated but the service state is not
 
     @staticmethod

--- a/src/fastly_bouncer/main.py
+++ b/src/fastly_bouncer/main.py
@@ -32,6 +32,7 @@ from fastly_bouncer.utils import (
 logger: logging.Logger = get_default_logger()
 
 exiting = False
+reload_acls = "start up"
 
 
 def sigterm_signal_handler(signum, frame):
@@ -42,6 +43,14 @@ def sigterm_signal_handler(signum, frame):
 
 signal.signal(signal.SIGTERM, sigterm_signal_handler)
 signal.signal(signal.SIGINT, sigterm_signal_handler)
+
+
+def sighup_signal_handler(signum, frame):
+    global reload_acls
+    reload_acls = "signal"
+
+
+signal.signal(signal.SIGHUP, sighup_signal_handler)
 
 
 async def setup_action_for_service(
@@ -195,7 +204,7 @@ async def setup_fastly_infra(config: Config, cleanup_mode):
             else:
                 cache = json.loads(s)
                 services = list(map(Service.from_jsonable_dict, cache["service_states"]))
-                logger.info(f"loaded exisitng infra using cache")
+                logger.info(f"loaded existing infra using cache")
                 if not cleanup_mode:
                     return services
     else:
@@ -236,7 +245,7 @@ def set_logger(config: Config):
 
 
 async def run(config: Config, services: List[Service]):
-    global VERSION
+    global VERSION, reload_acls
     crowdsec_client = StreamClient(
         lapi_url=config.crowdsec_config.lapi_url,
         api_key=config.crowdsec_config.lapi_key,
@@ -251,17 +260,23 @@ async def run(config: Config, services: List[Service]):
     while True and not exiting:
         new_state = crowdsec_client.get_current_decisions()
 
+        if reload_acls:
+            logger.info(f"Reload of ACLS triggered by {reload_acls}")
+            reload_acls = False
+            for s in services:
+                await s.reload_acls()
+
         async with trio.open_nursery() as n:
             for s in services:
                 n.start_soon(s.transform_state, new_state)
 
         new_states = list(map(lambda service: service.as_jsonable_dict(), services))
         if new_states != previous_states:
-            logger.debug("updating cache")
+            logger.debug("writing updated cache of fastly state")
             new_cache = {"service_states": new_states, "bouncer_version": VERSION}
             async with await trio.open_file(config.cache_path, "w") as f:
                 await f.write(json.dumps(new_cache, indent=4))
-            logger.debug("done updating cache")
+            logger.debug("done writing updated cache of fastly state")
             previous_states = new_states
 
         if exiting:


### PR DESCRIPTION
This fixes 4 things:
1. it adds a refresh all ACLs mode that is run at process start and on SIGHUP
2. It alters order of operations when ACLs are updated at fastly so the local state is not updated until faslty successfully updates
3. It adds an auto-repair mode. If fastly returns a 400 response to an ACL change, the ACL will be updated and the change will be run again.  
4. Bumps the batch size and ACL size from 100 to 1000. 