### PR TITLE
Fixes state drift

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ httpx
 trio
 python-dateutil
 pycrowdsec
+tenacity

--- a/src/fastly_bouncer/main.py
+++ b/src/fastly_bouncer/main.py
@@ -32,6 +32,7 @@ from fastly_bouncer.utils import (
 logger: logging.Logger = get_default_logger()
 
 exiting = False
+reload_acls = "start up"
 
 
 def sigterm_signal_handler(signum, frame):
@@ -42,6 +43,14 @@ def sigterm_signal_handler(signum, frame):
 
 signal.signal(signal.SIGTERM, sigterm_signal_handler)
 signal.signal(signal.SIGINT, sigterm_signal_handler)
+
+
+def sighup_signal_handler(signum, frame):
+    global reload_acls
+    reload_acls = "signal"
+
+
+signal.signal(signal.SIGHUP, sighup_signal_handler)
 
 
 async def setup_action_for_service(
@@ -195,7 +204,7 @@ async def setup_fastly_infra(config: Config, cleanup_mode):
             else:
                 cache = json.loads(s)
                 services = list(map(Service.from_jsonable_dict, cache["service_states"]))
-                logger.info(f"loaded exisitng infra using cache")
+                logger.info(f"loaded existing infra using cache")
                 if not cleanup_mode:
                     return services
     else:
@@ -236,7 +245,7 @@ def set_logger(config: Config):
 
 
 async def run(config: Config, services: List[Service]):
-    global VERSION
+    global VERSION, reload_acls
     crowdsec_client = StreamClient(
         lapi_url=config.crowdsec_config.lapi_url,
         api_key=config.crowdsec_config.lapi_key,
@@ -251,17 +260,23 @@ async def run(config: Config, services: List[Service]):
     while True and not exiting:
         new_state = crowdsec_client.get_current_decisions()
 
+        if reload_acls:
+            logger.info(f"Reload of ACLS triggered by {reload_acls}")
+            reload_acls = False
+            for s in services:
+                await s.reload_acls()
+
         async with trio.open_nursery() as n:
             for s in services:
                 n.start_soon(s.transform_state, new_state)
 
         new_states = list(map(lambda service: service.as_jsonable_dict(), services))
         if new_states != previous_states:
-            logger.debug("updating cache")
+            logger.debug("writing updated cache of fastly state")
             new_cache = {"service_states": new_states, "bouncer_version": VERSION}
             async with await trio.open_file(config.cache_path, "w") as f:
                 await f.write(json.dumps(new_cache, indent=4))
-            logger.debug("done updating cache")
+            logger.debug("done writing updated cache of fastly state")
             previous_states = new_states
 
         if exiting:


### PR DESCRIPTION
The bouncer ACLCollection state would get out of sync with what was in fastly. 

If a HTTP request to fastly failed due to a 429, the process would die and the state cache file could get out of sync.

This PR fixes 4 things:

1. it adds a refresh all ACLs mode that is run at process start and on SIGHUP
2. It alters order of operations when ACLs are updated at fastly so the local state is not updated until faslty successfully updates
3. It adds an auto-repair mode. If fastly returns a 400 response to an ACL change, the ACL will be updated and the change will be run again.
4. Bumps the batch size and ACL size from 100 to 1000.