### PR TITLE
feat(*): Retry on 429 and avoid cache out of sync issue

### DIFF
--- a/dev/config.yaml.example
+++ b/dev/config.yaml.example
@@ -1,3 +1,4 @@
+acl_fast_creation: false
 bouncer_version: 0.1.0
 cache_path: ./dev/cache/fastly-cache.json
 crowdsec_config:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = crowdsec-fastly-bouncer
-version = 0.3.0
+version = 0.4.0
 author = CrowdSec
 author_email = core.tech@crowdsec.net
 description = CrowdSec Fastly bouncer 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = crowdsec-fastly-bouncer
-version = 0.2.0
+version = 0.3.0
 author = CrowdSec
 author_email = core.tech@crowdsec.net
 description = CrowdSec Fastly bouncer 

--- a/src/fastly_bouncer/service.py
+++ b/src/fastly_bouncer/service.py
@@ -59,6 +59,22 @@ class ACLCollection:
         else:
             return await self._create_acls_sequential(acl_count)
 
+    async def _create_single_acl(self, index: int) -> ACL:
+        """
+        Shared helper method to create a single ACL with consistent naming and logging.
+        """
+        acl_name = f"crowdsec_{self.action}_{index}"
+        logger.debug(
+            with_suffix(f"Creating acl {acl_name} ", service_id=self.service_id)
+        )
+        acl = await self.api.create_acl_for_service(
+            service_id=self.service_id, version=self.version, name=acl_name
+        )
+        logger.info(
+            with_suffix(f"Acl {acl_name} created", service_id=self.service_id)
+        )
+        return acl
+
     async def _create_acls_fast(self, acl_count: int) -> List[ACL]:
         """
         Fast ACL creation using trio.start_soon for parallel execution.
@@ -66,22 +82,13 @@ class ACLCollection:
         """
         acls = [None] * acl_count
 
-        async def create_single_acl(index: int):
-            acl_name = f"crowdsec_{self.action}_{index}"
-            logger.debug(
-                with_suffix(f"Creating acl {acl_name} ", service_id=self.service_id)
-            )
-            acl = await self.api.create_acl_for_service(
-                service_id=self.service_id, version=self.version, name=acl_name
-            )
-            logger.info(
-                with_suffix(f"Acl {acl_name} created", service_id=self.service_id)
-            )
+        async def create_and_store_acl(index: int):
+            acl = await self._create_single_acl(index)
             acls[index] = acl
 
         async with trio.open_nursery() as nursery:
             for i in range(acl_count):
-                nursery.start_soon(create_single_acl, i)
+                nursery.start_soon(create_and_store_acl, i)
 
         return acls
 
@@ -93,16 +100,7 @@ class ACLCollection:
         acls = [None] * acl_count  # Pre-allocate list with correct size
         # Create ACLs in reverse order (highest index first, 0 last)
         for i in reversed(range(acl_count)):
-            acl_name = f"crowdsec_{self.action}_{i}"
-            logger.debug(
-                with_suffix(f"Creating acl {acl_name} ", service_id=self.service_id)
-            )
-            acl = await self.api.create_acl_for_service(
-                service_id=self.service_id, version=self.version, name=acl_name
-            )
-            logger.info(
-                with_suffix(f"Acl {acl_name} created", service_id=self.service_id)
-            )
+            acl = await self._create_single_acl(i)
             acls[i] = acl  # Place ACL at correct index position
 
             # Small delay to ensure proper ordering at Fastly API level
@@ -190,21 +188,37 @@ class ACLCollection:
         for expired_item in expired_items:
             self.remove_item(expired_item)
 
-    async def commit(self) -> None:
+    async def commit(self) -> bool:
         acls_to_change = list(
             filter(lambda acl: acl.entries_to_add or acl.entries_to_delete, self.acls)
         )
 
         if len(acls_to_change):
+            # Track success of each ACL update
+            results = {}
             async with trio.open_nursery() as n:
                 for acl in acls_to_change:
-                    n.start_soon(self.update_acl, acl)
-            logger.info(
-                with_suffix(
-                    f"ACL collection for {self.action} updated",
-                    service_id=self.service_id,
+                    n.start_soon(self.update_acl, acl, results)
+
+            # Check if all ACL updates succeeded
+            all_successful = all(results.values())
+            if all_successful:
+                logger.info(
+                    with_suffix(
+                        f"ACL collection for {self.action} updated successfully",
+                        service_id=self.service_id,
+                    )
                 )
-            )
+            else:
+                logger.warning(
+                    with_suffix(
+                        f"ACL collection for {self.action} had partial failures",
+                        service_id=self.service_id,
+                    )
+                )
+            return all_successful
+
+        return True  # No changes needed, consider successful
 
     def generate_conditions(self) -> str:
         conditions = []
@@ -213,7 +227,7 @@ class ACLCollection:
 
         return " || ".join(conditions)
 
-    async def update_acl(self, acl: ACL):
+    async def update_acl(self, acl: ACL, results: Dict = None):
         logger.debug(
             with_suffix(
                 f"Commiting changes to acl {acl.name}",
@@ -221,10 +235,15 @@ class ACLCollection:
                 acl_collection=self.action,
             )
         )
-        await self.api.process_acl(acl)
+        success = await self.api.process_acl(acl)
+
+        # Store result if results dict provided
+        if results is not None:
+            results[acl.id] = success
+
         logger.debug(
             with_suffix(
-                f"Commited changes to acl {acl.name}",
+                f"Commited changes to acl {acl.name} - {'success' if success else 'partial failure'}",
                 service_id=self.service_id,
                 acl_collection=self.action,
             )
@@ -427,7 +446,7 @@ class Service:
             self.countries_by_action[action].clear()
             self.autonomoussystems_by_action[action].clear()
 
-    async def transform_state(self, new_state: Dict[str, str]):
+    async def transform_state(self, new_state: Dict[str, str]) -> bool:
         """
         This method transforms the configuration of the service according to the "new_state".
         "new_state" is mapping of item->action. Eg  {"1.2.3.4": "ban", "CN": "captcha", "1234": "ban"}.
@@ -506,29 +525,52 @@ class Service:
             if new_systems:
                 logger.info(f"AS {new_systems} will get {action}")
 
-        await self.commit()
+        success = await self.commit()
+        return success
 
-    async def commit(self):
+    async def commit(self) -> bool:
+        # Track success of ACL collection updates
+        acl_results = {}
         async with trio.open_nursery() as n:
             for action in self.vcl_by_action:
-                n.start_soon(self.acl_collection_by_action[action].commit)
+                n.start_soon(self._commit_acl_collection, action, acl_results)
                 n.start_soon(self.update_vcl, action)
 
+        # Check if all ACL collections updated successfully
+        all_acl_successful = all(acl_results.values()) if acl_results else True
+
         if self._first_time and self.activate:
-            logger.debug(
-                with_suffix(
-                    f"Activating new service version {self.version}",
-                    service_id=self.service_id,
+            try:
+                logger.debug(
+                    with_suffix(
+                        f"Activating new service version {self.version}",
+                        service_id=self.service_id,
+                    )
                 )
-            )
-            await self.api.activate_service_version(self.service_id, self.version)
-            logger.info(
-                with_suffix(
-                    f"New service version {self.version} activated",
-                    service_id=self.service_id,
+                await self.api.activate_service_version(self.service_id, self.version)
+                logger.info(
+                    with_suffix(
+                        f"New service version {self.version} activated",
+                        service_id=self.service_id,
+                    )
                 )
-            )
-            self._first_time = False
+                self._first_time = False
+                return all_acl_successful  # Return ACL success status
+            except Exception as e:
+                logger.error(
+                    with_suffix(
+                        f"Failed to activate service version {self.version}: {e}",
+                        service_id=self.service_id,
+                    )
+                )
+                return False  # Activation failed
+
+        return all_acl_successful
+
+    async def _commit_acl_collection(self, action: str, results: Dict):
+        """Helper method to commit an ACL collection and track its success."""
+        success = await self.acl_collection_by_action[action].commit()
+        results[action] = success
 
     async def update_vcl(self, action: str):
         vcl = self.vcl_by_action[action]

--- a/src/fastly_bouncer/service.py
+++ b/src/fastly_bouncer/service.py
@@ -70,9 +70,7 @@ class ACLCollection:
         acl = await self.api.create_acl_for_service(
             service_id=self.service_id, version=self.version, name=acl_name
         )
-        logger.info(
-            with_suffix(f"Acl {acl_name} created", service_id=self.service_id)
-        )
+        logger.info(with_suffix(f"Acl {acl_name} created", service_id=self.service_id))
         return acl
 
     async def _create_acls_fast(self, acl_count: int) -> List[ACL]:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,12 @@
 import logging
 import sys
 import unittest
+from io import StringIO
 from logging.handlers import RotatingFileHandler
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from fastly_bouncer.config import Config, CrowdSecConfig
-from fastly_bouncer.main import buildClientParams, set_logger
+from fastly_bouncer.main import build_client_params, set_logger
 from fastly_bouncer.utils import VERSION, CustomFormatter
 
 
@@ -26,7 +27,7 @@ class TestBuildClientParams(unittest.TestCase):
 
     def test_basic_client_params(self):
         """Test basic client parameters generation"""
-        result = buildClientParams(self.config)
+        result = build_client_params(self.config)
 
         # Check required parameters
         self.assertEqual(result["api_key"], "test_api_key")
@@ -44,7 +45,7 @@ class TestBuildClientParams(unittest.TestCase):
             "brute-force",
         ]
 
-        result = buildClientParams(self.config)
+        result = build_client_params(self.config)
 
         self.assertEqual(
             result["include_scenarios_containing"], ("http", "ssh", "brute-force")
@@ -54,7 +55,7 @@ class TestBuildClientParams(unittest.TestCase):
         """Test exclude_scenarios_containing parameter"""
         self.crowdsec_config.exclude_scenarios_containing = ["test", "debug"]
 
-        result = buildClientParams(self.config)
+        result = build_client_params(self.config)
 
         self.assertEqual(result["exclude_scenarios_containing"], ("test", "debug"))
 
@@ -65,7 +66,7 @@ class TestBuildClientParams(unittest.TestCase):
         self.crowdsec_config.cert_path = "/path/to/cert.pem"
         self.crowdsec_config.ca_cert_path = "/path/to/ca.pem"
 
-        result = buildClientParams(self.config)
+        result = build_client_params(self.config)
 
         self.assertTrue(result["insecure_skip_verify"])
         self.assertEqual(result["key_path"], "/path/to/key.pem")
@@ -75,7 +76,7 @@ class TestBuildClientParams(unittest.TestCase):
     def test_optional_ssl_parameters_not_set(self):
         """Test that optional SSL parameters are not included when not set"""
         # Default values should not include optional SSL params
-        result = buildClientParams(self.config)
+        result = build_client_params(self.config)
 
         self.assertNotIn("insecure_skip_verify", result)
         self.assertNotIn("key_path", result)
@@ -87,7 +88,7 @@ class TestBuildClientParams(unittest.TestCase):
         self.crowdsec_config.include_scenarios_containing = []
         self.crowdsec_config.exclude_scenarios_containing = []
 
-        result = buildClientParams(self.config)
+        result = build_client_params(self.config)
 
         # Empty lists should not be included
         self.assertNotIn("include_scenarios_containing", result)
@@ -100,7 +101,7 @@ class TestBuildClientParams(unittest.TestCase):
             "another-source",
         ]
 
-        result = buildClientParams(self.config)
+        result = build_client_params(self.config)
 
         self.assertEqual(
             result["only_include_decisions_from"], ("custom-source", "another-source")
@@ -110,7 +111,7 @@ class TestBuildClientParams(unittest.TestCase):
         """Test different update frequency values"""
         self.config.update_frequency = 60
 
-        result = buildClientParams(self.config)
+        result = build_client_params(self.config)
 
         self.assertEqual(result["interval"], 60)
 
@@ -125,7 +126,7 @@ class TestBuildClientParams(unittest.TestCase):
         self.crowdsec_config.only_include_decisions_from = ["source1", "source2"]
         self.config.update_frequency = 120
 
-        result = buildClientParams(self.config)
+        result = build_client_params(self.config)
 
         # Verify all parameters are present
         expected_keys = {
@@ -231,7 +232,7 @@ class TestSetLogger(unittest.TestCase):
         with self.assertRaises(ValueError) as context:
             set_logger(self.config)
 
-        self.assertIn("unknown log mode invalid_mode", str(context.exception))
+        self.assertIn("Unknown log mode invalid_mode", str(context.exception))
 
     @patch("fastly_bouncer.main.logger")
     def test_set_logger_removes_existing_handlers(self, mock_logger):
@@ -303,6 +304,216 @@ class TestSetLogger(unittest.TestCase):
                 self.config.log_level = log_level_str
                 result = self.config.get_log_level()
                 self.assertEqual(result, expected_level)
+
+
+class TestRefreshMode(unittest.TestCase):
+    """Test refresh mode functionality"""
+
+    @patch("fastly_bouncer.main.parse_config_file")
+    @patch("fastly_bouncer.main.set_logger")
+    @patch("fastly_bouncer.main.trio")
+    @patch("sys.argv", ["crowdsec-fastly-bouncer", "-c", "config.yaml", "-r"])
+    def test_refresh_mode_argument_parsing(
+        self, mock_trio, mock_set_logger, mock_parse_config
+    ):
+        """Test that -r argument is properly parsed and passed to start function"""
+        from fastly_bouncer.main import main
+
+        # Mock config parsing
+        mock_config = Mock()
+        mock_parse_config.return_value = mock_config
+
+        # Mock Path.exists to return True
+        with patch("fastly_bouncer.main.Path") as mock_path:
+            mock_path.return_value.exists.return_value = True
+
+            try:
+                main()
+            except SystemExit:
+                pass
+
+        # Verify trio.run was called with refresh_mode=True
+        mock_trio.run.assert_called_once()
+        call_args = mock_trio.run.call_args
+        self.assertEqual(
+            len(call_args[0]), 4
+        )  # start, config, cleanup_mode, refresh_mode
+        self.assertEqual(call_args[0][2], False)  # cleanup_mode should be False
+        self.assertEqual(call_args[0][3], True)  # refresh_mode should be True
+
+    @patch("sys.argv", ["crowdsec-fastly-bouncer", "-r"])
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("sys.stderr", new_callable=StringIO)
+    def test_refresh_mode_requires_config_file(self, mock_stderr, mock_stdout):
+        """Test that -r requires -c argument"""
+        from fastly_bouncer.main import main
+
+        with self.assertRaises(SystemExit) as cm:
+            main()
+
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn(
+            "Refresh mode (-r) requires config file (-c)", mock_stderr.getvalue()
+        )
+
+    @patch("sys.argv", ["crowdsec-fastly-bouncer", "-c", "config.yaml", "-r", "-d"])
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("sys.stderr", new_callable=StringIO)
+    def test_refresh_mode_conflicts_with_cleanup(self, mock_stderr, mock_stdout):
+        """Test that -r cannot be used with -d"""
+        from fastly_bouncer.main import main
+
+        with self.assertRaises(SystemExit) as cm:
+            main()
+
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn(
+            "Refresh mode (-r) cannot be used with cleanup mode (-d)",
+            mock_stderr.getvalue(),
+        )
+
+    @patch(
+        "sys.argv",
+        ["crowdsec-fastly-bouncer", "-c", "config.yaml", "-r", "-g", "token"],
+    )
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("sys.stderr", new_callable=StringIO)
+    def test_refresh_mode_conflicts_with_generate(self, mock_stderr, mock_stdout):
+        """Test that -r cannot be used with -g"""
+        from fastly_bouncer.main import main
+
+        with self.assertRaises(SystemExit) as cm:
+            main()
+
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn(
+            "Refresh mode (-r) can only be used with config file (-c)",
+            mock_stderr.getvalue(),
+        )
+
+    @patch("sys.argv", ["crowdsec-fastly-bouncer", "-c", "config.yaml", "-r", "-e"])
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("sys.stderr", new_callable=StringIO)
+    def test_refresh_mode_conflicts_with_edit(self, mock_stderr, mock_stdout):
+        """Test that -r cannot be used with -e"""
+        from fastly_bouncer.main import main
+
+        with self.assertRaises(SystemExit) as cm:
+            main()
+
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn(
+            "Refresh mode (-r) can only be used with config file (-c)",
+            mock_stderr.getvalue(),
+        )
+
+    @patch(
+        "sys.argv",
+        ["crowdsec-fastly-bouncer", "-c", "config.yaml", "-r", "-o", "output.yaml"],
+    )
+    @patch("sys.stdout", new_callable=StringIO)
+    @patch("sys.stderr", new_callable=StringIO)
+    def test_refresh_mode_conflicts_with_output(self, mock_stderr, mock_stdout):
+        """Test that -r cannot be used with -o"""
+        from fastly_bouncer.main import main
+
+        with self.assertRaises(SystemExit) as cm:
+            main()
+
+        self.assertEqual(cm.exception.code, 1)
+        self.assertIn(
+            "Refresh mode (-r) can only be used with config file (-c)",
+            mock_stderr.getvalue(),
+        )
+
+    def test_start_refresh_mode_success(self):
+        """Test start function in refresh mode with existing infrastructure"""
+        import trio
+        from fastly_bouncer.main import start
+
+        async def run_test():
+            with patch(
+                "fastly_bouncer.main.discover_existing_fastly_infra"
+            ) as mock_discover, patch(
+                "fastly_bouncer.main.refresh_acls_on_startup"
+            ) as mock_refresh_acls, patch(
+                "fastly_bouncer.main.run"
+            ) as mock_run:
+
+                # Mock config
+                mock_config = Mock()
+                mock_config.cache_path = "/tmp/test_cache.json"
+
+                # Mock discovered services
+                mock_service = Mock()
+                mock_service.as_jsonable_dict.return_value = {"service": "test"}
+                mock_discover.return_value = [mock_service]
+
+                # Call start in refresh mode
+                await start(mock_config, False, True)
+
+                # Verify calls
+                mock_discover.assert_called_once_with(mock_config)
+                mock_refresh_acls.assert_called_once_with([mock_service])
+                mock_run.assert_called_once_with(mock_config, [mock_service])
+
+        trio.run(run_test)
+
+    def test_start_refresh_mode_no_infrastructure(self):
+        """Test start function in refresh mode with no existing infrastructure"""
+        import asyncio
+
+        from fastly_bouncer.main import start
+
+        async def run_test():
+            with patch(
+                "fastly_bouncer.main.discover_existing_fastly_infra"
+            ) as mock_discover, patch("fastly_bouncer.main.logger") as mock_logger:
+
+                # Mock config
+                mock_config = Mock()
+
+                # Mock no services found
+                mock_discover.return_value = []
+
+                # Call start in refresh mode
+                await start(mock_config, False, True)
+
+                # Verify error logging
+                mock_logger.error.assert_called_once_with(
+                    "No existing CrowdSec infrastructure found in Fastly to refresh"
+                )
+
+        asyncio.run(run_test())
+
+    def test_start_normal_mode(self):
+        """Test start function in normal mode"""
+        import asyncio
+
+        from fastly_bouncer.main import start
+
+        async def run_test():
+            with patch("fastly_bouncer.main.setup_fastly_infra") as mock_setup, patch(
+                "fastly_bouncer.main.refresh_acls_on_startup"
+            ) as mock_refresh_acls, patch("fastly_bouncer.main.run") as mock_run:
+
+                # Mock config
+                mock_config = Mock()
+
+                # Mock setup returning services only (no needs_acl_refresh)
+                mock_service = Mock()
+                mock_setup.return_value = [mock_service]
+
+                # Call start in normal mode
+                await start(mock_config, False, False)
+
+                # Verify calls
+                mock_setup.assert_called_once_with(mock_config, False)
+                # ACL refresh should NOT be called in normal mode (only with -r)
+                mock_refresh_acls.assert_not_called()
+                mock_run.assert_called_once_with(mock_config, [mock_service])
+
+        asyncio.run(run_test())
 
 
 if __name__ == "__main__":

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -319,3 +319,23 @@ class TestService(TestCase):
         )
         data_false = collection_false.as_jsonable_dict()
         self.assertFalse(data_false["fast_creation"])
+
+    def test_service_reload_acls(self):
+        """Test Service reload_acls method exists and has correct structure"""
+        # Create a service
+        service = Service(
+            api=self.mock_api,
+            version="3",
+            service_id="test_service",
+            recaptcha_site_key="test_key",
+            recaptcha_secret="test_secret",
+            activate=True,
+        )
+
+        # Verify the method exists
+        self.assertTrue(hasattr(service, "reload_acls"))
+        self.assertTrue(callable(getattr(service, "reload_acls")))
+
+        # Verify the helper method exists
+        self.assertTrue(hasattr(service, "_refresh_acl_collection"))
+        self.assertTrue(callable(getattr(service, "_refresh_acl_collection")))


### PR DESCRIPTION
- retry on 429 error with exponential backoff
- Only update local cache after ensuring API call was successful

- Include also https://github.com/crowdsecurity/cs-fastly-bouncer/pull/16